### PR TITLE
Add the pre-commit hooks to the mobile frontend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-json
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+        args: [--fix=lf]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ A better app for the public transportaion in Sofia, Sofia-grad, Bulgaria
 - Docker
 - Minikube
 - Kubectl
+- Python 3.9+ (for pre-commit)
+
+### Pre-commit hooks
+
+This repository uses `pre-commit` hooks to run lightweight checks before each commit.
+
+#### One-time setup
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+#### Run hooks manually
+
+```bash
+pre-commit run --all-files
+```
+
+Hook configuration is defined in `.pre-commit-config.yaml`.
 
 #### Start the development cluster
 ```


### PR DESCRIPTION
Add .pre-commit-config.yaml with a set of pre-commit hooks (e.g. check-added-large-files, check-ast, check-json, check-yaml, check-merge-conflict, debug-statements, detect-private-key, end-of-file-fixer, trailing-whitespace, mixed-line-ending). Update README.md to note Python 3.9+ requirement and include one-time setup and manual run instructions for pre-commit. These changes enable lightweight checks before commits and document how contributors should install and run the hooks.