### PR TITLE
Add psycopg2-binary to loyalty requirements

### DIFF
--- a/.github/workflows/loyalty.yml
+++ b/.github/workflows/loyalty.yml
@@ -40,7 +40,7 @@ jobs:
       POSTGRES_USER: ci_user
       POSTGRES_PASSWORD: ci_password
       POSTGRES_DB: ci_loyalty_db
-      DB_URL: postgresql+psycopg2://ci_user:ci_password@localhost:5432/ci_loyalty_db
+      DB_URL: postgresql+psycopg://ci_user:ci_password@localhost:5432/ci_loyalty_db
       POSTGRES_PORT: 5432
       FLASK_ENV: testing
       JWT_SECRET: test-jwt-secret

--- a/gitops/environments/dev/manifests/auth-image-patch.yaml
+++ b/gitops/environments/dev/manifests/auth-image-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: auth
-          image: docker.io/vilibalchev5/auth-new:7da140e7be2b3f1b93ea7a6fae4598de554e7252
+          image: docker.io/vilibalchev5/auth-new:1773ae38f7b841a72fde8f8893233995964ecf09

--- a/gitops/environments/dev/manifests/gtfs-image-patch.yaml
+++ b/gitops/environments/dev/manifests/gtfs-image-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: gtfs
-          image: docker.io/vilibalchev5/gtfs:7da140e7be2b3f1b93ea7a6fae4598de554e7252
+          image: docker.io/vilibalchev5/gtfs:1773ae38f7b841a72fde8f8893233995964ecf09

--- a/gitops/environments/dev/manifests/loyalty-image-patch.yaml
+++ b/gitops/environments/dev/manifests/loyalty-image-patch.yaml
@@ -8,4 +8,4 @@ spec:
     spec:
       containers:
         - name: loyalty
-          image: docker.io/vilibalchev5/loyalty:7da140e7be2b3f1b93ea7a6fae4598de554e7252
+          image: docker.io/vilibalchev5/loyalty:1773ae38f7b841a72fde8f8893233995964ecf09

--- a/gitops/services/loyalty/deployment.yaml
+++ b/gitops/services/loyalty/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                   name: loyalty-app-secrets
                   key: JWT_SECRET
             - name: DB_URL
-              value: postgresql://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@loyalty-postgres:$(POSTGRES_PORT)/$(POSTGRES_DB)
+              value: postgresql+psycopg://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@loyalty-postgres:$(POSTGRES_PORT)/$(POSTGRES_DB)
           resources:
             requests:
               cpu: 100m

--- a/services/loyalty/.env.example
+++ b/services/loyalty/.env.example
@@ -2,5 +2,5 @@ POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
 POSTGRES_PORT=5432
-DB_URL=postgresql://#user:password@addres:port/dbname
+DB_URL=postgresql+psycopg://#user:password@address:port/dbname
 JWT_SECRET= # should be the same as the one used by the auth service

--- a/services/loyalty/requirements.txt
+++ b/services/loyalty/requirements.txt
@@ -8,7 +8,7 @@ Flask-SQLAlchemy==3.1.1
 python-dotenv==1.0.0
 prometheus_flask_exporter==0.23.1
 gunicorn==23.0.0
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.1
 pytest==8.2.0
 pytest-cov==5.0.0
 pytest-html==4.0.0

--- a/services/loyalty/requirements.txt
+++ b/services/loyalty/requirements.txt
@@ -8,8 +8,7 @@ Flask-SQLAlchemy==3.1.1
 python-dotenv==1.0.0
 prometheus_flask_exporter==0.23.1
 gunicorn==23.0.0
-psycopg[binary]==3.2.1
-pytest==8.2.0
+psycopg[binary]==3.3.3
 pytest-cov==5.0.0
 pytest-html==4.0.0
 pytest-metadata==3.1.1

--- a/services/loyalty/requirements.txt
+++ b/services/loyalty/requirements.txt
@@ -8,6 +8,7 @@ Flask-SQLAlchemy==3.1.1
 python-dotenv==1.0.0
 prometheus_flask_exporter==0.23.1
 gunicorn==23.0.0
+psycopg2-binary==2.9.9
 pytest==8.2.0
 pytest-cov==5.0.0
 pytest-html==4.0.0


### PR DESCRIPTION
Include psycopg2-binary==2.9.9 in services/loyalty/requirements.txt to provide the PostgreSQL client library required for SQLAlchemy DB connectivity at runtime. This ensures the loyalty service has the necessary driver installed for local, CI, and production deployments.