### PR TITLE
Read container logs from /var/log/containers

### DIFF
--- a/gitops/monitoring/promtail/configmap.yaml
+++ b/gitops/monitoring/promtail/configmap.yaml
@@ -32,7 +32,6 @@ data:
             target_label: app
           - source_labels: [__meta_kubernetes_pod_node_name]
             target_label: node
-          - source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
-            separator: /
+          - source_labels: [__meta_kubernetes_pod_name, __meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
             target_label: __path__
-            replacement: /var/log/pods/*$1/*.log
+            replacement: /var/log/containers/$1_$2_$3-*.log

--- a/gitops/monitoring/promtail/daemonset.yaml
+++ b/gitops/monitoring/promtail/daemonset.yaml
@@ -34,18 +34,9 @@ spec:
             - name: varlogpods
               mountPath: /var/log/pods
               readOnly: true
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: 9080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /ready
-              port: 9080
-            initialDelaySeconds: 20
-            periodSeconds: 20
+            - name: varlogcontainers
+              mountPath: /var/log/containers
+              readOnly: true
           resources:
             requests:
               cpu: 50m
@@ -65,4 +56,8 @@ spec:
         - name: varlogpods
           hostPath:
             path: /var/log/pods
+            type: Directory
+        - name: varlogcontainers
+          hostPath:
+            path: /var/log/containers
             type: Directory


### PR DESCRIPTION
Switch Promtail to target container log files by building __path__ from pod name, namespace and container name and using /var/log/containers/*-*.log. Add a hostPath mount for /var/log/containers in the DaemonSet so Promtail can access those files, and remove the previous readiness/liveness HTTP probes. This aligns log discovery with container runtime symlink naming and centralizes collection from the containers directory.