### PR TITLE
Map pod labels to service_name in Promtail

### DIFF
--- a/gitops/monitoring/promtail/configmap.yaml
+++ b/gitops/monitoring/promtail/configmap.yaml
@@ -30,6 +30,10 @@ data:
             target_label: container
           - source_labels: [__meta_kubernetes_pod_label_app]
             target_label: app
+          - source_labels: [__meta_kubernetes_pod_label_app]
+            target_label: service_name
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            target_label: service_name
           - source_labels: [__meta_kubernetes_pod_node_name]
             target_label: node
           - source_labels: [__meta_kubernetes_pod_name, __meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]


### PR DESCRIPTION
Add relabel_configs to promtail config to set a service_name label from pod labels. This maps __meta_kubernetes_pod_label_app and __meta_kubernetes_pod_label_app_kubernetes_io_name to service_name so workloads using either labeling convention produce a consistent service_name for downstream logging/aggregation. (gitops/monitoring/promtail/configmap.yaml)