### PR TITLE
Promtail: adjust relabeling and pod log path

### DIFF
--- a/gitops/monitoring/promtail/configmap.yaml
+++ b/gitops/monitoring/promtail/configmap.yaml
@@ -22,6 +22,11 @@ data:
         kubernetes_sd_configs:
           - role: pod
         relabel_configs:
+          - action: replace
+            source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: __host__
+          - action: labelmap
+            regex: __meta_kubernetes_pod_label_(.+)
           - source_labels: [__meta_kubernetes_namespace]
             target_label: namespace
           - source_labels: [__meta_kubernetes_pod_name]
@@ -29,13 +34,13 @@ data:
           - source_labels: [__meta_kubernetes_pod_container_name]
             target_label: container
           - source_labels: [__meta_kubernetes_pod_label_app]
-            target_label: app
-          - source_labels: [__meta_kubernetes_pod_label_app]
             target_label: service_name
           - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
             target_label: service_name
           - source_labels: [__meta_kubernetes_pod_node_name]
             target_label: node
-          - source_labels: [__meta_kubernetes_pod_name, __meta_kubernetes_namespace, __meta_kubernetes_pod_container_name]
+          - action: replace
+            source_labels: [__meta_kubernetes_pod_uid, __meta_kubernetes_pod_container_name]
+            separator: /
             target_label: __path__
-            replacement: /var/log/containers/$1_$2_$3-*.log
+            replacement: /var/log/pods/*$1/*.log

--- a/gitops/monitoring/promtail/daemonset.yaml
+++ b/gitops/monitoring/promtail/daemonset.yaml
@@ -23,6 +23,11 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - -config.file=/etc/promtail/promtail.yaml
+          env:
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           ports:
             - name: http
               containerPort: 9080


### PR DESCRIPTION
Update Promtail config and DaemonSet to improve Kubernetes metadata and log file discovery. Adds a __host__ label from the pod's node name, a labelmap to import pod labels, and consolidates app labels into service_name. Change __path__ construction to use pod UID and container name with replacement /var/log/pods/*$1/*.log (and separator '/') so Promtail matches pod log paths reliably. Also add a HOSTNAME env var to the DaemonSet (from spec.nodeName) so the container has access to the node name.